### PR TITLE
[#9] 이미지 캐싱 처리

### DIFF
--- a/SearchOpenLibraryBook/SearchOpenLibraryBook.xcodeproj/project.pbxproj
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		CA53DD762E402F4B006E5935 /* AppScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53DD752E402F4B006E5935 /* AppScene.swift */; };
 		CA53DD782E40304C006E5935 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53DD772E40304C006E5935 /* MainCoordinator.swift */; };
 		CA53DD7A2E404B20006E5935 /* ViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53DD792E404B20006E5935 /* ViewFactory.swift */; };
+		CA53DDAD2E407067006E5935 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53DDAC2E407067006E5935 /* CachedAsyncImage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		CA53DD752E402F4B006E5935 /* AppScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScene.swift; sourceTree = "<group>"; };
 		CA53DD772E40304C006E5935 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		CA53DD792E404B20006E5935 /* ViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.swift; sourceTree = "<group>"; };
+		CA53DDAC2E407067006E5935 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -298,6 +300,7 @@
 			children = (
 				CA53DD5A2E3AF8DB006E5935 /* LoadingView.swift */,
 				CA53DD712E3FAA8D006E5935 /* SafariView.swift */,
+				CA53DDAC2E407067006E5935 /* CachedAsyncImage.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 				CA53DD5B2E3AF8DB006E5935 /* LoadingView.swift in Sources */,
 				CA53DD212E38A2EE006E5935 /* EndpointType.swift in Sources */,
 				CA53DD5D2E3B31B5006E5935 /* BookDetailView.swift in Sources */,
+				CA53DDAD2E407067006E5935 /* CachedAsyncImage.swift in Sources */,
 				CA53DD402E39BC71006E5935 /* SearchMainView.swift in Sources */,
 				CA53DD232E38A3D0006E5935 /* NetworkEnvironment.swift in Sources */,
 				CA53DD1F2E38A2B7006E5935 /* NetworkConstants.swift in Sources */,

--- a/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCardView.swift
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCardView.swift
@@ -112,9 +112,9 @@ struct BookCardView: View {
                 Text("상세보기")
                     .foregroundStyle(.black)
                     .font(.system(size: 14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
             })
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(lineWidth: 1)

--- a/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCoverView.swift
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCoverView.swift
@@ -35,7 +35,7 @@ struct BookCoverView: View {
             CachedAsyncImage(url: url) { image in
                 image
                     .resizable()
-                    .scaledToFill()
+                    .scaledToFit()
                     .frame(maxWidth: width)
                     .frame(height: height)
             } placeholder: {

--- a/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCoverView.swift
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookCoverView.swift
@@ -32,7 +32,7 @@ struct BookCoverView: View {
     var body: some View {
         if let urlString = urlString,
            let url = URL(string: urlString) {
-            AsyncImage(url: url) { image in
+            CachedAsyncImage(url: url) { image in
                 image
                     .resizable()
                     .scaledToFill()

--- a/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookDetailView.swift
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/Feature/Search/View/BookDetailView.swift
@@ -65,9 +65,10 @@ struct BookDetailView: View {
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundStyle(.black)
                     }
+                    .frame(maxWidth: .infinity)
                 })
-                .padding(.vertical, 12)
                 .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(lineWidth: 1)
@@ -80,7 +81,7 @@ struct BookDetailView: View {
 }
 
 #Preview {
-    let book = Book(title: "Swift programming", authors: ["George S. Clason"], firstPublishYear: 2023, languages: [], thumbnailURL: "", pageURL: "")
+    let book = Book(title: "Ff (The Alphabet)", authors: ["George S. Clason"], firstPublishYear: 2023, languages: [], thumbnailURL: "https://covers.openlibrary.org/b/id/14558369-M.jpg", pageURL: "")
     let router = NetworkRouter()
     let provider = NetworkProvider<SearchEndpoint>(router: router)
     let service = SearchServiceImpl(provider: provider)

--- a/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/UIComponents/CachedAsyncImage.swift
+++ b/SearchOpenLibraryBook/SearchOpenLibraryBook/Sources/UIComponents/CachedAsyncImage.swift
@@ -1,0 +1,117 @@
+//
+//  CachedAsyncImage.swift
+//  SearchOpenLibraryBook
+//
+//  Created by eunjuchoi on 8/4/25.
+//
+
+import SwiftUI
+
+struct CachedAsyncImage<Content: View, Placeholder: View>: View {
+    
+    // MARK: - Properties
+    
+    @State private var image: Image? = nil
+    @State private var isLoading = false
+    
+    private let url: URL?
+    private let content: (Image) -> Content
+    private let placeholder: () -> Placeholder
+    
+    // MARK: - Initializer
+    
+    init(
+        url: URL?,
+        @ViewBuilder content: @escaping (Image) -> Content,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.url = url
+        self.content = content
+        self.placeholder = placeholder
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        if let image = image {
+            content(image)
+        } else {
+            placeholder()
+                .onAppear {
+                    Task {
+                        await loadImage()
+                    }
+                }
+        }
+    }
+}
+
+// MARK: - Private Methods
+
+extension CachedAsyncImage {
+    
+    private func loadImage() async {
+        guard let url = url, !isLoading else { return }
+        
+        isLoading = true
+        
+        // 캐시 확인
+        let request = URLRequest(url: url)
+        if let cachedResponse = URLCache.shared.cachedResponse(for: request),
+           let cachedImage = UIImage(data: cachedResponse.data) {
+            await MainActor.run {
+                self.image = Image(uiImage: cachedImage)
+                self.isLoading = false
+            }
+            return
+        }
+        
+        // 캐시에 저장된 이미지 없다면 네트워크에서 이미지 다운로드
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            // Cache the image
+            let cachedData = CachedURLResponse(response: response, data: data)
+            URLCache.shared.storeCachedResponse(cachedData, for: request)
+            
+            if let uiImage = UIImage(data: data) {
+                await MainActor.run {
+                    self.image = Image(uiImage: uiImage)
+                    self.isLoading = false
+                }
+            }
+        } catch {
+            await MainActor.run {
+                self.isLoading = false
+            }
+        }
+    }
+}
+
+// MARK: - Initializers
+
+extension CachedAsyncImage {
+    
+    /// 기본값이 모두 정의되어있는 가장 간단한 이니셜라이저
+    init(url: URL?) where Content == AnyView, Placeholder == ProgressView<EmptyView, EmptyView> {
+        self.url = url
+        self.content = { image in
+            AnyView(
+                image
+                    .resizable()
+                    .scaledToFit()
+            )
+        }
+        self.placeholder = { ProgressView() }
+    }
+    
+    /// 기본 placeholder가 적용된 content를 외부에서 적용하는 이니셜라이저
+    init(
+        url: URL?,
+        @ViewBuilder content: @escaping (Image) -> Content
+    ) where Placeholder == ProgressView<EmptyView, EmptyView> {
+        self.url = url
+        self.content = content
+        self.placeholder = { ProgressView() }
+    }
+}


### PR DESCRIPTION
## 🔍 What is this PR?
`CachedAsyncImage`를 구현해 이미지 캐싱을 구현하였습니다.

## 📝 Changes
- 이미지 캐싱을 처리하는 로직을 포함하는 `CachedAsyncImage`를 구현
    - 인메모리/온디스크 방식 모두 지원하는 [URLCache](https://developer.apple.com/documentation/foundation/urlcache)를 이용 
- 기타 수정 사항
    -  Image contentMode를 `scaledToFill`에서 `scaledToFit`으로 수정 (고정적인 크기로 맞추다보니 책 표지가 잘려서 보이는 화면이 이상해서 수정함)
    - 버튼 터치 영역 확장 (기존에는 텍스트 영역만 터치 영역)

## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 검색 결과 화면 | ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-04 at 14 55 51](https://github.com/user-attachments/assets/c7a2e1dd-c90f-4cb0-b8a0-a57d1e11c618) | 
| 캐싱 전 | <img width="500" height="548" alt="스크린샷 2025-08-04 오후 1 38 39" src="https://github.com/user-attachments/assets/d7c1563d-cad1-425a-b392-3e00b3920b29" /> |
| 캐싱 후 | <img width="500" height="541" alt="스크린샷 2025-08-04 오후 1 49 51" src="https://github.com/user-attachments/assets/9024a1b5-1f14-4865-8271-822d17d159c8" /> |

결과: 전체 메모리 사용량이 크게 줄지는 않았지만 (검색 기능 특성상 새로운 데이터를 받을 일이 많기 때문) 동일 검색 결과 혹은 위로 스크롤 시 메모리 사용량 증가 하지 않고 유지됨을 확인

## 📮 관련 이슈

- Resolved: #9

